### PR TITLE
A mark can be used only once

### DIFF
--- a/mgp2pdf.py
+++ b/mgp2pdf.py
@@ -464,6 +464,7 @@ class Mark(SimpleChunk):
 
     def __init__(self):
         self.pos = None
+        self.used = False
 
     def drawOn(self, canvas, x, y, w, h):
         self.pos = x, y
@@ -481,7 +482,11 @@ class Again(SimpleChunk):
 
     def drawOn(self, canvas, x, y, w, h):
         assert self.mark.pos is not None, "Mark not initialized yet!"
+        if self.mark.used:
+            # a mark can be used only once
+            return x, y
         mx, my = self.mark.pos
+        self.mark.used = True
         return x, my
 
     def __str__(self):


### PR DESCRIPTION
Unfortunately this fix breaks two of my slide decks:
- `samples/pyconlt/talk.mgp`
- `samples/pyconlt/python-lt.mgp`

They're quite broken when I try to view them with `mgp`, so I should try to fix them too.  Which is harder than it sounds, especially given that my handling of %again isn't quite correct, even after this fix.
