### PR TITLE
[WIP] Fix %newimage

### DIFF
--- a/mgp2pdf.py
+++ b/mgp2pdf.py
@@ -202,7 +202,7 @@ class Slide(object):
         """
         line = self.currentOrNewLine()
         line.add(Image(filename, zoom, raised_by))
-        # XXX: self.closeCurrentLine()?
+        self.closeCurrentLine()
 
     def addMark(self):
         """Add a mark to the current line and return it.
@@ -798,6 +798,7 @@ class Presentation(object):
         self._lastlineno = 0
         self._use_defaults = True
         self._continuing = False
+        self._applying_defaults = False
         self._directives_used_in_this_line = set()
         self.mark = None
 
@@ -931,7 +932,12 @@ class Presentation(object):
             else:
                 raise MgpSyntaxError("newimage %s not handled yet" % k)
         filename = os.path.join(self.basedir, args[-1])
+        if not self._continuing and not self._applying_defaults:
+            self._lastlineno += 1
+            self._applyDefaults()
         self.slides[-1].addImage(filename, zoom, raised_by)
+        if self._applying_defaults:
+            self.slides[-1].reopenCurrentLine()
 
     def _handleDirective_mark(self, parts):
         """Handle %mark.
@@ -970,7 +976,7 @@ class Presentation(object):
         """
         if not self.mark:
             raise MgpSyntaxError("%again without %mark")
-        self._handleText('')
+        ##self._handleText('')
         self.slides[-1].addAgain(self.mark)
 
     def _handleUnknownDirective(self, parts):
@@ -1018,17 +1024,24 @@ class Presentation(object):
                 assert False, 'unknown argspec %r' % arg
         return tuple(results)
 
+    def _applyDefaults(self):
+        """Apply the default directives for this line"""
+        assert not self._applying_defaults
+        if self._use_defaults:
+            self._applying_defaults = True
+            for part in self.defaultDirectives.get(self._lastlineno, []):
+                word = self._splitArgs(part)[0]
+                if word not in self._directives_used_in_this_line:
+                    self._handleDirective(part)
+            self._applying_defaults = False
+
     def _handleText(self, line):
         """Handle a line of text that is not a comment or a directive."""
         if self.inPreamble():
             raise MgpSyntaxError('No text allowed in the preamble')
         if not self._continuing:
             self._lastlineno += 1
-            if self._use_defaults:
-                for part in self.defaultDirectives.get(self._lastlineno, []):
-                    word = self._splitArgs(part)[0]
-                    if word not in self._directives_used_in_this_line:
-                        self._handleDirective(part)
+            self._applyDefaults()
         line = line.rstrip('\n').replace(r'\#', '#').replace(r'\\', '\\')
         self.slides[-1].addText(line)
         self._continuing = False

--- a/samples/synthetic/images.mgp
+++ b/samples/synthetic/images.mgp
@@ -1,6 +1,16 @@
 %default 1 fore "black", back "white", center
 %page
 
+When do images cause line breaks?
+
+%newimage "povlogo.png"
+%newimage "povlogo.png"
+%newimage "povlogo.png"
+text
+
+Always
+%page
+
 So, -raise doesn't appear to do anything
 
 %newimage "povlogo.png"


### PR DESCRIPTION
Images are supposed to take a line of their own (unless you use %cont)
and their positioning should be influenced by %default directives.

This is a work in progress that triggers assertion errors when you use
%again inside a %default directive.  It also breaks my slide decks quite
badly and doesn't actually fix image alignment anyway.

DO NOT MERGE.
