### PR TITLE
Fix: 'r' is the slant id for Roman

### DIFF
--- a/mgp2pdf.py
+++ b/mgp2pdf.py
@@ -1084,7 +1084,7 @@ class Fonts(object):
             elif enginefontname.count('-') == 2:
                 # family-weight-slant
                 family, weight, slant = enginefontname.split('-')
-                slant = {'i': 'italic', 'm': 'roman'}[slant]
+                slant = {'i': 'italic', 'r': 'roman'}[slant]
                 enginefontname = '%s:weight=%s:slant=%s' % (family, weight, slant)
         filename = subprocess.Popen(
             ['fc-match', enginefontname, '-f', '%{file}'],


### PR DESCRIPTION
According to https://wiki.archlinux.org/index.php/X_Logical_Font_Description#Font_name_elements